### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,11 @@ This is a fork of the original [sublime-yardoc](https://github.com/revathskumar/
 
 ### Installation
 
-### With Package Control
-The easiest way to install this is with [Package Control](http://wbond.net/sublime\_packages/package\_control).
+- In Command Palette (ctrl+shift+p or cmd+shift+p) select: `Package Control: Add Repository`
+  - Add this project's GitHub URL: https://github.com/phts/sublime-yardoc
 
-   * If you just went and installed Package Control, you probably need to restart Sublime Text 2    before doing this next bit.
-   * Bring up the Command Palette (Command+Shift+p on OS X, Control+Shift+p on Linux/Windows).
-   * Select "Package Control: Install Package" (it'll take a few seconds)
-   * Select Yardoc when the list appears.
-
-Package Control will automatically keep Yardoc up to date with the latest version.
-
-### Without Package Control
-
-Go to your Sublime Text 2 **Packages** directory and clone the repository using the command below:
-
-    git clone git@github.com:revathskumar/sublime-yardoc.git yardoc
-
-Don't forget to keep updating it, though!
+- In the Command Palette, select: `Package Control: Install Package`
+  - Search for `sublime-yardoc` and ensure the source references this repository
 
 ### Usage
 


### PR DESCRIPTION
The current installation instructions are strictly for the original project, not this fork.

Thanks for making this change! I was hoping to improve my usage of yard syntax, but the older project had the `0x0d` issues that you fixed. I thought it might be nice for future folks to have an easy time to install if they've never used packages outside the main repo.